### PR TITLE
[HH-10][PLANNER] Save itinerary in history for a user

### DIFF
--- a/holiholic_database/src/main/java/com/holiholic/database/DatabaseManager.java
+++ b/holiholic_database/src/main/java/com/holiholic/database/DatabaseManager.java
@@ -558,20 +558,22 @@ public class DatabaseManager {
                 return false;
             }
 
-            JSONObject history = fetchObjectFromDatabase(Constants.HISTORY_PLANNER_DB_PATH);
-            JSONArray userHistory;
-            if (history.has(uid)) {
-                userHistory = history.getJSONArray(uid);
-            } else {
-                userHistory = new JSONArray();
+            synchronized (DatabaseManager.class) {
+                JSONObject history = fetchObjectFromDatabase(Constants.HISTORY_PLANNER_DB_PATH);
+                JSONArray userHistory;
+                if (history.has(uid)) {
+                    userHistory = history.getJSONArray(uid);
+                } else {
+                    userHistory = new JSONArray();
+                }
+
+                // remove the uid from the body
+                body.remove("uid");
+                userHistory.put(body);
+                history.put(uid, userHistory);
+
+                return saveHistory(Constants.HISTORY_PLANNER_DB_PATH, history);
             }
-
-            // remove the uid from the body
-            body.remove("uid");
-            userHistory.put(body);
-            history.put(uid, userHistory);
-
-            return saveHistory(Constants.HISTORY_PLANNER_DB_PATH, history);
         } catch (Exception e) {
             e.printStackTrace();
             return false;

--- a/holiholic_database/src/main/java/com/holiholic/database/DatabaseManager.java
+++ b/holiholic_database/src/main/java/com/holiholic/database/DatabaseManager.java
@@ -530,4 +530,51 @@ public class DatabaseManager {
             return null;
         }
     }
+
+    /* saveHistory - Save a plan into a specific user history in the database
+     *
+     *  @return             : success or not
+     *  @path               : the history database path
+     *  @history            : the updated history
+     */
+    private static boolean saveHistory(String path, JSONObject history) {
+        return syncDatabase(path, history);
+    }
+
+    /* updateHistory - Save a plan into a specific user history
+     *
+     *  @return             : success or not
+     *  @body               : the network json body request
+     */
+    public static boolean updateHistory(JSONObject body) {
+        try {
+            String cityName = body.getString("city");
+            String uid = body.getString("uid");
+
+            LOGGER.log(Level.FINE, "New request from user {0} to save itinerary from {1} city",
+                       new Object[]{uid, cityName});
+
+            if (!containsUser(uid)) {
+                return false;
+            }
+
+            JSONObject history = fetchObjectFromDatabase(Constants.HISTORY_PLANNER_DB_PATH);
+            JSONArray userHistory;
+            if (history.has(uid)) {
+                userHistory = history.getJSONArray(uid);
+            } else {
+                userHistory = new JSONArray();
+            }
+
+            // remove the uid from the body
+            body.remove("uid");
+            userHistory.put(body);
+            history.put(uid, userHistory);
+
+            return saveHistory(Constants.HISTORY_PLANNER_DB_PATH, history);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
 }

--- a/holiholic_database/src/main/java/com/holiholic/database/constant/Constants.java
+++ b/holiholic_database/src/main/java/com/holiholic/database/constant/Constants.java
@@ -12,4 +12,5 @@ public class Constants {
     public final static String TOPICS_DB_PATH = System.getProperty("user.dir") + "/db/topics/topics.json";
     public final static String AVAILABLE_TOPICS_DB_PATH = System.getProperty("user.dir") + "/db/topics/available_topics.json";
     public final static String PEOPLE_DB_PATH = System.getProperty("user.dir") + "/db/people/people.json";
+    public final static String HISTORY_PLANNER_DB_PATH = System.getProperty("user.dir") + "/db/history/planner/itineraries.json";
 }

--- a/holiholic_database/src/main/java/com/holiholic/database/controller/HistoryController.java
+++ b/holiholic_database/src/main/java/com/holiholic/database/controller/HistoryController.java
@@ -1,0 +1,22 @@
+package com.holiholic.database.controller;
+
+import com.holiholic.database.DatabaseManager;
+import org.json.JSONObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class HistoryController {
+
+    @RequestMapping(value = "/updateHistory", headers = "Content-Type=application/json", method = RequestMethod.POST)
+    @ResponseBody
+    public ResponseEntity<Boolean> updateHistory(@RequestBody String body) {
+        try {
+            return new ResponseEntity<>(DatabaseManager.updateHistory(new JSONObject(body)), HttpStatus.OK);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new ResponseEntity<>(false, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/holiholic_planner/pom.xml
+++ b/holiholic_planner/pom.xml
@@ -48,6 +48,13 @@
 			<version>20180813</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.6</version>
+		</dependency>
+
 	</dependencies>
 
 	<properties>

--- a/holiholic_planner/src/main/java/com/holiholic/planner/constant/Constants.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/constant/Constants.java
@@ -7,6 +7,7 @@ import com.holiholic.planner.utils.Interval;
  */
 public class Constants {
     public final static String CONTAINS_USER_URL = "http://localhost:8092/containsUser";
+    public final static String UPDATE_HISTORY_URL = "http://localhost:8092/updateHistory";
     public final static String DATABASE_PATH = System.getProperty("user.dir") + "/db/";
 
     // Eating defaults

--- a/holiholic_planner/src/main/java/com/holiholic/planner/controllers/HistoryController.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/controllers/HistoryController.java
@@ -1,0 +1,22 @@
+package com.holiholic.planner.controllers;
+
+import com.holiholic.planner.database.DatabaseManager;
+import org.json.JSONObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class HistoryController {
+
+    @RequestMapping(value = "/updateHistory", headers="Content-Type=application/json", method = RequestMethod.POST)
+    @ResponseBody
+    public ResponseEntity<Boolean> updateHistory(@RequestBody String body)  {
+        try {
+            return new ResponseEntity<>(DatabaseManager.updateHistory(new JSONObject(body)), HttpStatus.OK);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new ResponseEntity<>(false, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/holiholic_planner/src/main/java/com/holiholic/planner/database/DatabaseManager.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/database/DatabaseManager.java
@@ -7,8 +7,15 @@ import com.holiholic.planner.travel.City;
 import com.holiholic.planner.utils.*;
 import com.holiholic.planner.utils.Reader;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.springframework.http.HttpStatus;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -583,5 +590,48 @@ public class DatabaseManager {
             urlConnection.disconnect();
         }
         return data;
+    }
+
+    /* updateHistory - Save a plan into a specific user history
+     *
+     *  @return             : success or not
+     *  @body               : the network json body request
+     */
+    public static boolean updateHistory(JSONObject body) {
+        try {
+            String cityName = body.getString("city");
+            String uid = body.getString("uid");
+
+            LOGGER.log(Level.FINE, "New request from user {0} to save itinerary from {1} city",
+                       new Object[]{uid, cityName});
+            return postContentToURL(body, Constants.UPDATE_HISTORY_URL);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /* postContentToURL - Create a post request given the body and the url
+     *
+     *  @return             : success or not
+     *  @body               : the body of the HTTP POST request
+     *  @strUrl             : the url for the HTTP POST request
+     */
+    private static boolean postContentToURL(JSONObject body, String strUrl) {
+        try {
+            StringEntity entity = new StringEntity(body.toString(2),
+                                                   ContentType.APPLICATION_JSON);
+
+            HttpClient httpClient = HttpClientBuilder.create().build();
+            HttpPost request = new HttpPost(strUrl);
+            request.setEntity(entity);
+
+            HttpResponse response = httpClient.execute(request);
+            int responseCode = response.getStatusLine().getStatusCode();
+            return responseCode == HttpStatus.OK.value();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
     }
 }


### PR DESCRIPTION
After a user picked one itinerary from the multiple plans, he can chose to save it in the system's history.

This action can be done using a HTTP POST request.

**Request example**
`http://localhost:8090/updateHistory`
and the body something similar to the below **json**:
```
{
  "city": "bucharest",
  "uid": "adbf5a778175ee757c34d0eba4e932bc",
  "timeStamp": "3 Jun 2008 11:05",
  "plan": [
    {
      "parkTime": 0,
      "rating": 4.3,
      "mealType": "unknown",
      "needToGetTheCarBack": false,
      "plannedHour": "09:00",
      "type": "starting_point",
      "carPlaceName": "",
      "duration": 0,
      "carPlaceId": -1,
      "needToParkHere": false,
      "modeOfTravel": "driving",
      "name": "Name of the current place",
      "id": -1,
      "timeToNext": 15
    },
    ...
  ]
}
```