### PR TITLE
[HH-13] Avoid file does not exist in the database

### DIFF
--- a/holiholic_database/src/main/java/com/holiholic/database/feed/Feed.java
+++ b/holiholic_database/src/main/java/com/holiholic/database/feed/Feed.java
@@ -368,6 +368,30 @@ public abstract class Feed {
         return pathPrefix + city + ".json";
     }
 
+    /* createDatabaseEmptyFile - Creates an object which is used for the database to initialize an empty database
+     *
+     *  @return             : the json object
+     */
+    JSONObject createDatabaseEmptyFile() {
+        JSONObject content = new JSONObject();
+        content.put(getType() + "Count", 0);
+        content.put(getType(), new JSONObject());
+        return content;
+    }
+
+    /* initDatabaseFile - Checks if the database file already exists and if not creates an empty file
+     *                    For example creates and empty "posts_bucharest.json" file
+     *
+     *  @return             : void
+     */
+    void initDatabaseFile() {
+        try {
+            DatabaseManager.initDatabaseFileObject(getDatabaseFullPath(getPath(), getCity()), createDatabaseEmptyFile());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     /* saveFeed - Saves in the database the updates for the feeds
      *
      *  @return             : success or not

--- a/holiholic_database/src/main/java/com/holiholic/database/feed/Guide.java
+++ b/holiholic_database/src/main/java/com/holiholic/database/feed/Guide.java
@@ -23,6 +23,7 @@ public class Guide extends Feed implements IFeedEditable {
         idField = "gid";
         type = "guide";
         setLogger(LOGGER);
+        initDatabaseFile();
     }
 
     @Override

--- a/holiholic_database/src/main/java/com/holiholic/database/feed/GuideProfile.java
+++ b/holiholic_database/src/main/java/com/holiholic/database/feed/GuideProfile.java
@@ -21,37 +21,22 @@ public class GuideProfile extends Feed implements IFeedEditable {
     GuideProfile(String city, JSONObject body) {
         this.city = city;
         this.body = body;
+        if (body.has("uidGuide")) {
+            path = DatabaseManager.getGuideProfilePath(body.getString("uidGuide"));
+        }
         idField = "gpid";
         type = "guideProfile";
         setLogger(LOGGER);
-        initPath();
+        initDatabaseFile();
     }
 
-    private void initPath() {
-        try {
-            path = DatabaseManager.getGuideProfilePath(body.getString("uidGuide"));
-            initFile();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void initFile() {
-        synchronized (DatabaseManager.class) {
-            String fullPath = getDatabaseFullPath(path, city);
-            File f = new File(fullPath);
-            if (f.exists() && !f.isDirectory()) {
-                return;
-            }
-
-            // populate empty file
-            JSONObject content = new JSONObject();
-            content.put(type + "Count", 0);
-            content.put(type, new JSONObject());
-            content.put("likes", createEmptyLikesObject());
-
-            DatabaseManager.syncDatabase(fullPath, content);
-        }
+    @Override
+    JSONObject createDatabaseEmptyFile() {
+        JSONObject content = new JSONObject();
+        content.put(getType() + "Count", 0);
+        content.put(getType(), new JSONObject());
+        content.put("likes", createEmptyLikesObject());
+        return content;
     }
 
     @Override

--- a/holiholic_database/src/main/java/com/holiholic/database/feed/Post.java
+++ b/holiholic_database/src/main/java/com/holiholic/database/feed/Post.java
@@ -22,6 +22,7 @@ public class Post extends Feed implements IFeedEditable {
         idField = "pid";
         type = "post";
         setLogger(LOGGER);
+        initDatabaseFile();
     }
 
     @Override

--- a/holiholic_database/src/main/java/com/holiholic/database/feed/Question.java
+++ b/holiholic_database/src/main/java/com/holiholic/database/feed/Question.java
@@ -22,6 +22,7 @@ public class Question extends Feed implements IFeedEditable {
         idField = "qid";
         type = "question";
         setLogger(LOGGER);
+        initDatabaseFile();
     }
 
     @Override


### PR DESCRIPTION
Every time we request to access the file from the database we check if the file already exists. If not we need to create it, in order to avoid future `FileNotFound` or other `I/O` exceptions.


This PR solves this issue by creating and empty json `object` or `array` considering the request.