### PR TITLE
[HH-23][PLANNER] Consider visiting interval when retrieving places information

### DIFF
--- a/holiholic_planner/src/main/java/com/holiholic/planner/database/DatabaseManager.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/database/DatabaseManager.java
@@ -101,14 +101,14 @@ public class DatabaseManager {
         return filteredPlaces;
     }
 
-    /* filterPlaceByVisitingHours - Scan places and select only those that can be visited in the period the user selected
+    /* filterPlacseByVisitingHours - Scan places and select only those that can be visited in the period the user selected
      *                              For example, an user can select multiple days
      *
      *  @return             : the filtered places
      *  @places             : the list of places from the city
      *  @visitingInterval   : the interval selected by user (multiple days with different intervals per day)
      */
-    private static List<Place> filterPlaceByVisitingHours(List<Place> places, OpeningPeriod visitingInterval) {
+    private static List<Place> filterPlacesByVisitingHours(List<Place> places, OpeningPeriod visitingInterval) {
         List<Place> filteredPlaces = new ArrayList<>();
         for (Place place : places) {
             if (place.canVisit(visitingInterval)) {
@@ -156,7 +156,7 @@ public class DatabaseManager {
 
             List<Place> placesFilteredByTags = filterPlacesByTags(city.places, body.getJSONArray("tags"));
             OpeningPeriod visitingInterval = deserializeOpeningPeriod(body.getJSONArray("visitingInterval"));
-            List<Place> openPlaces = filterPlaceByVisitingHours(placesFilteredByTags, visitingInterval);
+            List<Place> openPlaces = filterPlacesByVisitingHours(placesFilteredByTags, visitingInterval);
 
             return serializeToNetwork(openPlaces);
         } catch (Exception e) {
@@ -548,6 +548,10 @@ public class DatabaseManager {
             Calendar end = deserializeHour(close.getString("time"));
             int dayOpen = open.getInt("day");
             int dayClose = close.getInt("day");
+            // set the correct day
+            start.set(Calendar.DAY_OF_WEEK, dayOpen + 1);
+            end.set(Calendar.DAY_OF_WEEK, dayClose + 1);
+            
             // this means the bar is closing after midnight
             if (dayClose != dayOpen) {
                 end.add(Calendar.DAY_OF_WEEK, 1);

--- a/holiholic_planner/src/main/java/com/holiholic/planner/models/Place.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/models/Place.java
@@ -4,6 +4,7 @@ import com.holiholic.planner.utils.Enums;
 import com.holiholic.planner.utils.GeoPosition;
 import com.holiholic.planner.utils.Interval;
 import com.holiholic.planner.utils.OpeningPeriod;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.*;
@@ -76,14 +77,14 @@ public class Place implements Serializable, Comparable<Place> {
      */
     @Override
     public String toString() {
-        return serialize().toString();
+        return serializeToPlan().toString();
     }
 
-    /* serialize - Serialize the place into a json format
+    /* serializeToPlan - Serialize the place into a json format which is used for plan representation
      *
      *  @return       : the serialized place
      */
-    public JSONObject serialize() {
+    public JSONObject serializeToPlan() {
         JSONObject response = new JSONObject();
         response.put("id", id);
         response.put("name", name);
@@ -99,7 +100,43 @@ public class Place implements Serializable, Comparable<Place> {
         response.put("carPlaceName", carPlaceName);
         response.put("parkTime", parkTime);
         response.put("mealType", Enums.MealType.serialize(mealType));
+        response.put("latitude", location.latitude);
+        response.put("longitude", location.longitude);
         return response;
+    }
+
+    /* serializeToNetwork - Serialize the place into a json format for network
+     *
+     *  @return       : the serialized place
+     */
+    public JSONObject serializeToNetwork() {
+        JSONObject response = new JSONObject();
+        response.put("id", id);
+        response.put("name", name);
+        response.put("rating", rating);
+        response.put("duration", durationVisit);
+        response.put("type", type);
+        response.put("parkTime", parkTime);
+        response.put("latitude", location.latitude);
+        response.put("longitude", location.longitude);
+        response.put("checkIns", checkIns);
+        response.put("wantToGo", wantToGoNumber);
+        response.put("imageUrl", imageUrl);
+        response.put("openingHours", openingPeriod.serialize());
+        response.put("tags", serializeTags());
+        return response;
+    }
+
+    /* serializeTags - Serialize the tags into a json format for network
+     *
+     *  @return       : the serialized tags
+     */
+    private JSONArray serializeTags() {
+        JSONArray result = new JSONArray();
+        for (String tag : tags) {
+            result.put(tag);
+        }
+        return result;
     }
 
     /* canVisit - Checks if the place can be visited an the specified hour
@@ -109,6 +146,15 @@ public class Place implements Serializable, Comparable<Place> {
      */
     public boolean canVisit(Calendar hour) {
         return openingPeriod.canVisit(hour);
+    }
+
+    /* canVisit - Checks if the place can be visited given multiple days interval with each day other constraints
+     *
+     *  @return       : true/false
+     *  @hour         : user interval
+     */
+    public boolean canVisit(OpeningPeriod userInterval) {
+        return openingPeriod.canVisit(userInterval);
     }
 
     /* canVisit - Checks if the place is non stop

--- a/holiholic_planner/src/main/java/com/holiholic/planner/planner/PlanManager.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/planner/PlanManager.java
@@ -58,15 +58,9 @@ public class PlanManager {
             p.durationVisit = place.getInt("duration");
             // update the time in the city place
             int oldTime = city.placeMappings.get(id).durationVisit;
-            city.placeMappings.get(id).durationVisit = (oldTime + p.durationVisit) / 2;
 
-            try {
-                synchronized (PlanManager.class) {
-                    // put the duration directly in the stored json
-                    city.jsonPlacesArray.getJSONObject(p.id).put("duration", city.placeMappings.get(id).durationVisit);
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
+            synchronized (PlanManager.class) {
+                city.placeMappings.get(id).durationVisit = (oldTime + p.durationVisit) / 2;
             }
 
             places.add(p);
@@ -92,13 +86,6 @@ public class PlanManager {
 
             // update also the total number of check-ins
             city.totalCheckIns++;
-
-            try {
-                // Put the number of check-ins directly in the stored json
-                city.jsonPlacesArray.getJSONObject(p.id).put("checkIns", cityPlace.checkIns);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
         }
     }
 
@@ -119,13 +106,6 @@ public class PlanManager {
 
             // update also the total number of want to go
             city.totalWantToGo++;
-
-            try {
-                // Put the number of want-to-go directly in the stored json
-                city.jsonPlacesArray.getJSONObject(p.id).put("wantToGo", cityPlace.wantToGoNumber);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
         }
     }
 

--- a/holiholic_planner/src/main/java/com/holiholic/planner/travel/City.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/travel/City.java
@@ -1,7 +1,6 @@
 package com.holiholic.planner.travel;
 
 import com.holiholic.planner.models.Place;
-import org.json.JSONArray;
 
 import java.util.HashMap;
 import java.util.List;
@@ -20,9 +19,6 @@ public class City {
     // fast retrieval knowing the id for the desired place instance
     public Map<Integer, Place> placeMappings;
     private Map<Integer, List<Place>> restaurants;
-
-    // The json used to retrieve the places
-    public JSONArray jsonPlacesArray;
 
     public long totalCheckIns = 1;
     public long totalWantToGo = 1;

--- a/holiholic_planner/src/main/java/com/holiholic/planner/utils/Interval.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/utils/Interval.java
@@ -1,5 +1,7 @@
 package com.holiholic.planner.utils;
 
+import org.json.JSONObject;
+
 import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Comparator;
@@ -42,7 +44,7 @@ public class Interval implements Comparator<Interval>, Serializable {
      *
      *  @return             : the end calendar (hour)
      */
-    public Calendar getEnd() {
+    Calendar getEnd() {
         return end;
     }
 
@@ -50,7 +52,7 @@ public class Interval implements Comparator<Interval>, Serializable {
      *
      *  @return             : true / false
      */
-    public boolean isNonStop() {
+    private boolean isNonStop() {
         return nonStop;
     }
 
@@ -58,7 +60,7 @@ public class Interval implements Comparator<Interval>, Serializable {
      *
      *  @return             : true / false
      */
-    public boolean isClosed() {
+    boolean isClosed() {
         return closed;
     }
 
@@ -253,7 +255,20 @@ public class Interval implements Comparator<Interval>, Serializable {
      *  @hour               : the hour we want to format
      */
     public static String serializeHour(Calendar hour) {
-        return String.format("%02d:%02d", hour.get(Calendar.HOUR_OF_DAY), hour.get(Calendar.MINUTE));
+        return String.format("%02d%02d", hour.get(Calendar.HOUR_OF_DAY), hour.get(Calendar.MINUTE));
+    }
+
+    /* serialize - Returns a json object representation of the given hour and day of the week
+     *
+     *  @return             : the json object representation
+     *  @hour               : the hour
+     *  @day                : the day for the interval
+     */
+    private static JSONObject serialize(Calendar hour, int day) {
+        JSONObject result = new JSONObject();
+        result.put("time", serializeHour(hour));
+        result.put("day", day);
+        return result;
     }
 
     /* clone - Deep copy of the current object
@@ -275,5 +290,17 @@ public class Interval implements Comparator<Interval>, Serializable {
         intervalClone.nonStop = this.nonStop;
         intervalClone.closed = this.closed;
         return intervalClone;
+    }
+
+    /* serialize - Returns a json format representation of the current interval given the day
+     *
+     *  @return             : serialization
+     *  @day                : the day of the week for the current interval
+     */
+    JSONObject serialize(int day) {
+        JSONObject result = new JSONObject();
+        result.put("open", serialize(getStart(), day));
+        result.put("close", serialize(getEnd(), day));
+        return result;
     }
 }

--- a/holiholic_planner/src/main/java/com/holiholic/planner/utils/OpeningPeriod.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/utils/OpeningPeriod.java
@@ -1,8 +1,9 @@
 package com.holiholic.planner.utils;
 
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.*;
 
 /* OpeningPeriod - Holds information about the place opening hours
  *
@@ -45,10 +46,10 @@ public class OpeningPeriod {
     public void setClosedAllDays() {
         setDayMappings();
         this.intervals = new HashMap<>();
-        for (int day = 0; day < 7; day++) {
+        for (int dayOfWeek = 0; dayOfWeek < 7; dayOfWeek++) {
             Interval closeInterval = new Interval();
             closeInterval.setClosed(true);
-            this.intervals.put(day, closeInterval);
+            this.intervals.put(dayOfWeek, closeInterval);
         }
     }
 
@@ -73,6 +74,58 @@ public class OpeningPeriod {
         }
         int day = dayMappings.get(hour.get(Calendar.DAY_OF_WEEK));
         return !intervals.get(day).isClosed() && intervals.get(day).isBetween(hour);
+    }
+
+    /* getOpenDays - Get a list of open days
+     *
+     *  @return             : a list of indexes for each open day
+     */
+    private List<Integer> getOpenDays() {
+        List<Integer> openDays = new ArrayList<>();
+        for (int dayOfWeek = 1; dayOfWeek <= 7; dayOfWeek++) {
+            if (isNonStop() || !isClosed(dayOfWeek)) {
+                openDays.add(dayOfWeek);
+            }
+        }
+        return openDays;
+    }
+
+    /* canVisit - Check if the current period (visiting interval) can be visited in the given period
+     *            For example each place has an opening period which consist of daily visiting Interval
+     *            The period parameter can be the day(s) the user wants to visit
+     *            So an use case would be when the user wants to check the availability of a place for Monday and Friday
+     *
+     *  @return             : true or false
+     *  @period             : the period we want to check if it is between the current opening period
+     */
+    public boolean canVisit(OpeningPeriod period) {
+        if (isNonStop()) {
+            return true;
+        }
+
+        List<Integer> openDays = period.getOpenDays();
+
+        for (int dayOfWeek : openDays) {
+            if (isClosed(dayOfWeek)) {
+                continue;
+            }
+            Interval placeInterval = getInterval(dayOfWeek);
+            Interval periodInterval = period.getInterval(dayOfWeek);
+
+            if (placeInterval.getStart().before(periodInterval.getStart())
+                && periodInterval.getStart().before(placeInterval.getEnd())) {
+                return true;
+            }
+            if (placeInterval.getStart().before(periodInterval.getEnd())
+                && periodInterval.getEnd().before(placeInterval.getEnd())) {
+                return true;
+            }
+            if (periodInterval.getStart().before(placeInterval.getStart())
+                && placeInterval.getStart().before(periodInterval.getEnd())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /* isNonStop - Checks if the place is non stop opened
@@ -114,5 +167,39 @@ public class OpeningPeriod {
             intervalsClone.put(interval.getKey(), (Interval) interval.getValue().clone());
         }
         return new OpeningPeriod(intervalsClone);
+    }
+
+    /* serializeNonStopPeriod - Returns a json format representation for a non stop place
+     *
+     *  @return             : serialization
+     */
+    private JSONObject serializeNonStopPeriod() {
+        JSONObject result = new JSONObject();
+        JSONObject nonStopObject = new JSONObject();
+        nonStopObject.put("time", "0000");
+        nonStopObject.put("day", 0);
+        result.put("open", nonStopObject);
+        return result;
+    }
+
+    /* serialize - Returns a json format representation for the current opening period
+     *
+     *  @return             : serialization
+     */
+    public JSONArray serialize() {
+        JSONArray result = new JSONArray();
+
+        if (isNonStop()) {
+            result.put(serializeNonStopPeriod());
+            return result;
+        }
+
+        for (int dayOfWeek = 1; dayOfWeek <= 7; dayOfWeek++) {
+            if (!isClosed(dayOfWeek)) {
+                result.put(getInterval(dayOfWeek).serialize(dayMappings.get(dayOfWeek)));
+            }
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
When an user wants to plan a trip, we should complete the `city`, `tags` and `visiting interval` fields to get a list of places which he can visit.

This can be done with a `HTTP POST` request.

**_Request example_**
`http://localhost:8090/getPlaces` and the **body** in `json` format
```
{
  "city": "bucharest",
  "uid": "6753a27847d7e4e3518b1837c2f0e716",
  "tags": [
    "local",
    "art"
  ],
  "visitingInterval": [
    {
      "close": {
        "time": "2359",
        "day": 2
      },
      "open": {
        "time": "0900",
        "day": 2
      }
    }
  ]
}
```