### PR TITLE
[HH-46][PLANNER] Set visit places only outside

### DIFF
--- a/holiholic_planner/src/main/java/com/holiholic/planner/models/Place.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/models/Place.java
@@ -36,7 +36,7 @@ public class Place implements Comparable<Place> {
     public String fixedAt = "anytime";      // The time when the user wants to visit a place
     public LocalDateTime fixedTime;
     public long waitTime = 0;               // how much to wait between visiting 2 places
-    public boolean interior = false;        // specify if user wants to enter place
+    public boolean visitInside = false;     // specify if user wants to enter place
 
     private Place() {
 
@@ -76,7 +76,7 @@ public class Place implements Comparable<Place> {
      *  @time         : time to check if the place can be visited
      */
     public boolean canVisit(LocalDateTime time) {
-        return !interior || timeFrame.canVisit(time);
+        return !visitInside || timeFrame.canVisit(time);
     }
 
     /* canVisit - Checks if the place can be visited given multiple days interval with each day other constraints
@@ -123,7 +123,7 @@ public class Place implements Comparable<Place> {
         other.fixedAt = fixedAt;
         other.fixedTime = fixedTime;
         other.waitTime = waitTime;
-        other.interior = interior;
+        other.visitInside = visitInside;
         return other;
     }
 

--- a/holiholic_planner/src/main/java/com/holiholic/planner/models/Place.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/models/Place.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 /* Place - The internal representation model for a place
  *
  */
-public class Place implements Comparable<Place>, Cloneable {
+public class Place implements Comparable<Place> {
     public int id;
     public String name;
     private String description;
@@ -37,6 +37,10 @@ public class Place implements Comparable<Place>, Cloneable {
     public LocalDateTime fixedTime;
     public long waitTime = 0;               // how much to wait between visiting 2 places
     public boolean interior = false;        // specify if user wants to enter place
+
+    private Place() {
+
+    }
 
     private Place(int id, String name, GeoPosition location) {
         this.id = id;
@@ -92,52 +96,35 @@ public class Place implements Comparable<Place>, Cloneable {
         return timeFrame.isNonStop();
     }
 
-    /* clone - Returns a shallow copy of the current object
+    /* copy - Returns a new reference making a deep copy of the current object
      *
-     *  @return       : a clone of the current object
+     *  @return       : copy of the current object
      */
-    @Override
-    public Place clone() {
-        Place copy = null;
-        try{
-            copy = (Place) super.clone();
-        } catch (Exception e){
-            e.printStackTrace();
-        }
-        return copy;
-    }
-
-    /* reset - Reset to default values the place before planning
-     *
-     *  @return         : void
-     *  @place          : place to reset
-     */
-    private void reset(Place place) {
-        if (place != null) {
-            place.plannedHour = null;
-            place.durationToNext = 0;
-            place.distanceToNext = 0;
-            place.travelMode = Enums.TravelMode.UNKNOWN;
-            place.getCarBack = false;
-            place.carPlaceId = -1;
-            place.carPlaceName = "";
-            place.parkHere = false;
-            place.mealType = Enums.MealType.UNKNOWN;
-            place.fixedAt = "anytime";
-            place.fixedTime = null;
-            place.waitTime = 0;
-            place.interior = false;
-        }
-    }
-
-    /* clone - Returns a copy of the current object making deep copy of fields used in planning
-     *
-     *  @return       : a clone of the current object
-     */
-    public Place deepClone() {
-        Place copy = clone();
-        reset(copy);
-        return copy;
+    public Place copy() {
+        Place other = new Place();
+        other.id = id;
+        other.name = name;
+        other.description = description;
+        other.imageUrl = imageUrl;
+        other.rating = rating;
+        other.placeCategory = placeCategory;
+        other.durationVisit = durationVisit;
+        other.location = location;
+        other.timeFrame = timeFrame;
+        other.plannedHour = plannedHour;
+        other.durationToNext = durationToNext;
+        other.distanceToNext = distanceToNext;
+        other.travelMode = travelMode;
+        other.getCarBack = getCarBack;
+        other.carPlaceId = carPlaceId;
+        other.carPlaceName = carPlaceName;
+        other.parkHere = parkHere;
+        other.mealType = mealType;
+        other.fixedAt = fixedAt;
+        other.fixedTime = fixedTime;
+        other.waitTime = waitTime;
+        other.interior = interior;
+        return other;
     }
 
     /* compareTo - Compares two places based on their fixed time
@@ -196,5 +183,25 @@ public class Place implements Comparable<Place>, Cloneable {
             e.printStackTrace();
             return null;
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (getClass() != o.getClass()) {
+            return false;
+        }
+        Place other = (Place) o;
+        return this.id == other.id;
     }
 }

--- a/holiholic_planner/src/main/java/com/holiholic/planner/models/Place.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/models/Place.java
@@ -36,6 +36,7 @@ public class Place implements Comparable<Place>, Cloneable {
     public String fixedAt = "anytime";      // The time when the user wants to visit a place
     public LocalDateTime fixedTime;
     public long waitTime = 0;               // how much to wait between visiting 2 places
+    public boolean interior = false;        // specify if user wants to enter place
 
     private Place(int id, String name, GeoPosition location) {
         this.id = id;
@@ -71,7 +72,7 @@ public class Place implements Comparable<Place>, Cloneable {
      *  @time         : time to check if the place can be visited
      */
     public boolean canVisit(LocalDateTime time) {
-        return timeFrame.canVisit(time);
+        return !interior || timeFrame.canVisit(time);
     }
 
     /* canVisit - Checks if the place can be visited given multiple days interval with each day other constraints
@@ -125,6 +126,7 @@ public class Place implements Comparable<Place>, Cloneable {
             place.fixedAt = "anytime";
             place.fixedTime = null;
             place.waitTime = 0;
+            place.interior = false;
         }
     }
 

--- a/holiholic_planner/src/main/java/com/holiholic/planner/planner/PlanManager.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/planner/PlanManager.java
@@ -51,7 +51,7 @@ public class PlanManager {
             if (placeInfo.getBoolean("isFixed")) {
                 place.fixedAt = placeInfo.getString("fixedAt");
             }
-            place.interior = placeInfo.getBoolean("interior");
+            place.visitInside = placeInfo.getBoolean("visitInside");
             place.durationVisit = placeInfo.getInt("duration");
             // update the time in the city place
             int oldTime = city.getPlaces().get(id).durationVisit;

--- a/holiholic_planner/src/main/java/com/holiholic/planner/planner/PlanManager.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/planner/PlanManager.java
@@ -51,7 +51,7 @@ public class PlanManager {
             if (placeInfo.getBoolean("isFixed")) {
                 place.fixedAt = placeInfo.getString("fixedAt");
             }
-
+            place.interior = placeInfo.getBoolean("interior");
             place.durationVisit = placeInfo.getInt("duration");
             // update the time in the city place
             int oldTime = city.getPlaces().get(id).durationVisit;

--- a/holiholic_planner/src/main/java/com/holiholic/planner/planner/PlanManager.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/planner/PlanManager.java
@@ -46,7 +46,7 @@ public class PlanManager {
             JSONObject placeInfo = placesFromRequest.getJSONObject(i);
             int id = placeInfo.getInt("id");
             // need this clone to avoid concurrent modifications
-            Place place = CloneFactory.clone(city.getPlaces().get(id));
+            Place place = city.getPlaces().get(id).copy();
 
             if (placeInfo.getBoolean("isFixed")) {
                 place.fixedAt = placeInfo.getString("fixedAt");

--- a/holiholic_planner/src/main/java/com/holiholic/planner/planner/Planner.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/planner/Planner.java
@@ -1042,7 +1042,7 @@ class Planner {
         response.put("latitude", place.location.latitude);
         response.put("longitude", place.location.longitude);
         response.put("waitTime", place.waitTime);
-        response.put("interior", place.interior);
+        response.put("visitInside", place.visitInside);
         return response;
     }
 }

--- a/holiholic_planner/src/main/java/com/holiholic/planner/planner/Planner.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/planner/Planner.java
@@ -1049,6 +1049,7 @@ class Planner {
         response.put("latitude", place.location.latitude);
         response.put("longitude", place.location.longitude);
         response.put("waitTime", place.waitTime);
+        response.put("interior", place.interior);
         return response;
     }
 }

--- a/holiholic_planner/src/main/java/com/holiholic/planner/planner/PlannerTask.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/planner/PlannerTask.java
@@ -13,7 +13,7 @@ import java.util.concurrent.Callable;
  */
 public class PlannerTask implements Callable<Boolean> {
     private Place current;
-    private Set<Integer> open;
+    private Set<Place> open;
     private List<Place> solution;
     private LocalDateTime time;
     private double score;
@@ -22,7 +22,7 @@ public class PlannerTask implements Callable<Boolean> {
     private PriorityQueue<Place> fixed;
     private Planner planner;
 
-    PlannerTask(Place current, Set<Integer> open, List<Place> solution, LocalDateTime time, double score, int carPlaceId,
+    PlannerTask(Place current, Set<Place> open, List<Place> solution, LocalDateTime time, double score, int carPlaceId,
                 int returnDurationToCar, PriorityQueue<Place> fixed, Planner planner) {
         this.current = current;
         this.open = open;

--- a/holiholic_planner/src/main/java/com/holiholic/planner/utils/CloneFactory.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/utils/CloneFactory.java
@@ -14,14 +14,18 @@ import java.util.*;
  *
  */
 public class CloneFactory {
-    public static Set<Integer> clone(Set<Integer> set) {
-        return new HashSet<>(set);
+    public static Set<Place> clone(Set<Place> set) {
+        Set<Place> cloneSet = new HashSet<>();
+        for (Place place : set) {
+            cloneSet.add(place.copy());
+        }
+        return cloneSet;
     }
 
     public static List<Place> clone(List<Place> list) {
         List<Place> cloneList = new ArrayList<>();
         for (Place place : list) {
-            cloneList.add(place.clone());
+            cloneList.add(place.copy());
         }
         return cloneList;
     }
@@ -29,12 +33,8 @@ public class CloneFactory {
     public static PriorityQueue<Place> clone(PriorityQueue<Place> pq) {
         PriorityQueue<Place> pqClone = new PriorityQueue<>();
         for (Place place : pq) {
-            pqClone.add(place.clone());
+            pqClone.add(place.copy());
         }
         return pqClone;
-    }
-
-    public static Place clone(Place place) {
-        return place.deepClone();
     }
 }

--- a/holiholic_planner/src/main/java/com/holiholic/planner/utils/ThreadManager.java
+++ b/holiholic_planner/src/main/java/com/holiholic/planner/utils/ThreadManager.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
  *
  */
 public class ThreadManager {
-    private static ThreadManager instance;
     private static ThreadPoolExecutor executor;
 
     private ThreadManager() {
@@ -30,16 +29,7 @@ public class ThreadManager {
      *  @return       : the thread manager instance
      */
     public static ThreadManager getInstance() {
-        if (instance == null) {
-            //synchronized block to remove overhead
-            synchronized (ThreadManager.class) {
-                if(instance == null) {
-                    instance = new ThreadManager();
-                }
-            }
-        }
-
-        return instance;
+        return new ThreadManager();
     }
 
     /* invokeAll - Execute a list of tasks and wait for their execution


### PR DESCRIPTION
Consider the option of visiting only the surroundings of a place, not entering (buying a ticket) in the place. This way, the place will be open `24 Hours` and the `duration visit` will be `30 mins` (**1800 sec**).

A practical case is when the user only wants to see a building from outside, make a picture but not enter the place inside.

Planner
---
Added the `visitInside` field in the **place info object** to specify if visit only outside or inside. This thing can be done using the following example in the request:
```
{
  "id" : 10,
  "duration" : 1800,
  "isFixed" : false,
  "fixedAt" : "-",
  "visitInside" : true / false
}
```


-------
Also modified the `getPlaces` method to allow user to choose if wants only open places or to see them all.
The HTTP request should now include a field `openOnly` to specify this.
Example of requests:
- open only set `TRUE`
```
{
  "city": "bucharest",
  "uid": "bff149a0b87f5b0e00d9dd364e9ddaa0",
  "categories": [
    "Outdoors & Recreation"
  ],
  "timeFrame": [
    {
      "close": {
        "time": "2359",
        "day": 2
      },
      "open": {
        "time": "0900",
        "day": 2
      }
    }
  ],
  "openOnly": true
}
```
- open only set `FALSE`
```
{
  "city": "bucharest",
  "uid": "bff149a0b87f5b0e00d9dd364e9ddaa0",
  "categories": [
    "Outdoors & Recreation"
  ]
  "openOnly": false
}
```